### PR TITLE
Enable CPU-only builds on macOS

### DIFF
--- a/spconv/csrc/sparse/cpu_core.py
+++ b/spconv/csrc/sparse/cpu_core.py
@@ -23,6 +23,9 @@ class OMPLib(pccm.Class):
         self.add_include("tensorview/parallel/all.h")
         if compat.InWindows:
             self.build_meta.add_public_cflags("cl", "/openmp")
+        elif compat.InMacOS:
+            # OpenMP on macOS fails tests, so disable OpenMP for now
+            pass
         else:
             self.build_meta.add_public_cflags("g++", "-fopenmp")
             self.build_meta.add_public_cflags("clang++", "-fopenmp")

--- a/spconv/pytorch/ops.py
+++ b/spconv/pytorch/ops.py
@@ -1197,7 +1197,10 @@ def indice_conv_backward(features: torch.Tensor,
     pair_in = indice_pairs_tv[int(inverse)]
     pair_out = indice_pairs_tv[int(not inverse)]
 
-    stream = get_current_stream()
+    if features.is_cuda:
+        stream = get_current_stream()
+    else:
+        stream = 0
     indice_pair_num_cpu = indice_pair_num.cpu().tolist()
     if subm and all(x == 0 for x in indice_pair_num_cpu):
         return (din, dfilters.reshape(filters_shape))

--- a/test/test_conv.py
+++ b/test/test_conv.py
@@ -248,7 +248,9 @@ def test_spconv3d():
     test_case = TestCase()
     np.random.seed(484)
     torch.manual_seed(48848)
-    devices = ["cuda:0"]
+    devices = ["cpu"]
+    if torch.has_cuda:
+        devices += ["cuda:0"]
     shapes = [[19, 18, 17]]
     batchsizes = [1, 2]
 
@@ -259,17 +261,19 @@ def test_spconv3d():
     paddings = [0, 1, 2]
     dilations = [1, 2, 3]
     algos = [
-        ConvAlgo.Native, ConvAlgo.MaskImplicitGemm,
+        ConvAlgo.Native, 
+        ConvAlgo.MaskImplicitGemm,
         ConvAlgo.MaskSplitImplicitGemm
     ]
-    algos = [ConvAlgo.Native, ConvAlgo.MaskImplicitGemm, ConvAlgo.MaskSplitImplicitGemm]
 
     for dev, shape, bs, IC, OC, k, s, p, d, al in params_grid(
             devices, shapes, batchsizes, in_channels, out_channels, ksizes,
             strides, paddings, dilations, algos):
         if all([s > 1, d > 1]):
             continue  # don't support this.
-        # print(dev, shape, bs, IC, OC, k, s, p, d)
+        if dev == "cpu" and al is not ConvAlgo.Native:
+            continue # CPU only supports ConvAlgo.Native
+        # print(dev, shape, bs, IC, OC, k, s, p, d, al)
         device = torch.device(dev)
         num_points = [1500] * bs
         dtype = torch.float32
@@ -360,7 +364,9 @@ def test_spdeconv3d():
     test_case = TestCase()
 
     np.random.seed(484)
-    devices = ["cuda:0"]
+    devices = ["cpu"]
+    if torch.has_cuda:
+        devices += ["cuda:0"]
     shapes = [[19, 18, 17]]
     batchsizes = [1, 2]
 
@@ -372,8 +378,9 @@ def test_spdeconv3d():
     dilations = [1, 2, 3]
 
     algos = [
-        ConvAlgo.Native, ConvAlgo.MaskImplicitGemm,
-        ConvAlgo.MaskSplitImplicitGemm
+        ConvAlgo.Native,
+        # ConvAlgo.MaskImplicitGemm,
+        # ConvAlgo.MaskSplitImplicitGemm
     ]
 
     for dev, shape, bs, IC, OC, k, s, p, d, al in params_grid(
@@ -381,6 +388,8 @@ def test_spdeconv3d():
             strides, paddings, dilations, algos):
         if all([s > 1, d > 1]):
             continue  # don't support this.
+        if dev == "cpu" and al is not ConvAlgo.Native:
+            continue # CPU only supports ConvAlgo.Native
         device = torch.device(dev)
         num_points = [1000] * bs
         dtype = torch.float32
@@ -463,7 +472,9 @@ def test_spmaxpool3d():
     test_case = TestCase()
 
     np.random.seed(485)
-    devices = ["cuda:0"]
+    devices = ["cpu"]
+    if torch.has_cuda:
+        devices += ["cuda:0"]
     shapes = [[19, 18, 17]]
     batchsizes = [1, 2]
 
@@ -478,8 +489,9 @@ def test_spmaxpool3d():
     # paddings = [0]
     # dilations = [1]
     algos = [
-        ConvAlgo.Native, ConvAlgo.MaskImplicitGemm,
-        ConvAlgo.MaskSplitImplicitGemm
+        ConvAlgo.Native, 
+        # ConvAlgo.MaskImplicitGemm,
+        # ConvAlgo.MaskSplitImplicitGemm
     ]
 
 
@@ -488,6 +500,8 @@ def test_spmaxpool3d():
             strides, paddings, dilations, algos):
         if all([s > 1, d > 1]):
             continue  # don't support this.
+        if dev == "cpu" and al is not ConvAlgo.Native:
+            continue # CPU only supports ConvAlgo.Native
         device = torch.device(dev)
         num_points = [1000] * bs
 
@@ -599,4 +613,7 @@ def test_spglobalmaxpool3d():
         test_case.assertAllClose(din_np, din_sparse_np, atol=1e-4)
 
 if __name__ == "__main__":
+    test_spconv3d()
+    test_spdeconv3d()
+    test_spmaxpool3d()
     test_spglobalmaxpool3d()

--- a/test/test_conv.py
+++ b/test/test_conv.py
@@ -558,7 +558,9 @@ def test_spglobalmaxpool3d():
     test_case = TestCase()
 
     np.random.seed(485)
-    devices = ["cpu:0", "cuda:0"]
+    devices = [] # no support for globalpool for CPU yet
+    if torch.has_cuda:
+        devices += ["cuda:0"]
     shapes = [[19, 18, 17]]
     batchsizes = [1, 2]
 

--- a/test/test_conv.py
+++ b/test/test_conv.py
@@ -379,8 +379,8 @@ def test_spdeconv3d():
 
     algos = [
         ConvAlgo.Native,
-        # ConvAlgo.MaskImplicitGemm,
-        # ConvAlgo.MaskSplitImplicitGemm
+        ConvAlgo.MaskImplicitGemm,
+        ConvAlgo.MaskSplitImplicitGemm
     ]
 
     for dev, shape, bs, IC, OC, k, s, p, d, al in params_grid(
@@ -490,8 +490,8 @@ def test_spmaxpool3d():
     # dilations = [1]
     algos = [
         ConvAlgo.Native, 
-        # ConvAlgo.MaskImplicitGemm,
-        # ConvAlgo.MaskSplitImplicitGemm
+        ConvAlgo.MaskImplicitGemm,
+        ConvAlgo.MaskSplitImplicitGemm
     ]
 
 


### PR DESCRIPTION
This PR enables CPU-only builds on macOS. It in addition to the changes to `spconv`, this also requires some changes to `ccimport` and `cumm`. They are implemented at https://github.com/tilmantroester/ccimport/tree/macos_support and 
https://github.com/tilmantroester/cumm/tree/macos_cpu_only. Let me know if you want PRs for those as well.

I've tested this on an arm64 mac, with both Apple and conda clang. 
For development installs (`pip install -e`), both JIT and non-JIT work. Standard installs require the non-JIT build.

Compiling with OpenMP works but the results are unstable, so I disabled OpenMP on macOS.

`tests/test_conv.py` passes for the cases where CPU implementations are available (i.e. `ConvAlgo.Native` but not for example `SparseGlobalMaxPool`).