### PR TITLE
Fix SparseGlobalAvgPool in pool.py

### DIFF
--- a/spconv/pytorch/pool.py
+++ b/spconv/pytorch/pool.py
@@ -270,9 +270,9 @@ class SparseGlobalMaxOrAvgPool(SparseModule):
             real_inds = out_indices[i, :counts_cpu_np[i]]
             real_features = input.features[real_inds]
             if self.is_mean:
-                real_features_reduced = torch.mean(real_features, dim=0)[0]
+                real_features_reduced = torch.mean(real_features, dim=0)
             else:
-                real_features_reduced = torch.max(real_features, dim=0)[0]
+                real_features_reduced = torch.amax(real_features, dim=0)
             res_features_list.append(real_features_reduced)
         res = torch.stack(res_features_list)
         return res 


### PR DESCRIPTION
Fixing issue of SparseGlobalAvgPool giving back only the first feature. For clearer code I also changed max to amax so the magic indexing vanishes.