### PR TITLE
fix global avg pool bug

### DIFF
--- a/spconv/pytorch/pool.py
+++ b/spconv/pytorch/pool.py
@@ -270,7 +270,7 @@ class SparseGlobalMaxOrAvgPool(SparseModule):
             real_inds = out_indices[i, :counts_cpu_np[i]]
             real_features = input.features[real_inds]
             if self.is_mean:
-                real_features_reduced = torch.mean(real_features, dim=0)[0]
+                real_features_reduced = torch.mean(real_features, dim=0, keepdim=False)
             else:
                 real_features_reduced = torch.max(real_features, dim=0)[0]
             res_features_list.append(real_features_reduced)


### PR DESCRIPTION
refer to [the latest torch documentation](https://pytorch.org/docs/stable/generated/torch.mean.html), here is an example:
```python
real_features = torch.rand((36, 512))
real_features_reduced = torch.mean(real_features, dim=0)[0]
print(real_features_reduced.shape)
# torch.Size([])
real_features_reduced = torch.mean(real_features, dim=0, keepdim=False)
print(real_features_reduced.shape)
# torch.Size([512])
```