### PR TITLE
update amp.custom_fwd to avoid future warning

### DIFF
--- a/spconv/pytorch/functional.py
+++ b/spconv/pytorch/functional.py
@@ -42,7 +42,12 @@ def identity_decorator(func: _T) -> _T:
     return func
 
 
-if PYTORCH_VERSION >= [1, 6, 0]:
+if PYTORCH_VERSION >= [2, 4, 0]:
+    import torch.amp as amp
+    _TORCH_CUSTOM_FWD = amp.custom_fwd(cast_inputs=torch.float16, device_type="cuda")
+    _TORCH_CUSTOM_BWD = amp.custom_bwd
+    
+elif PYTORCH_VERSION >= [1, 6, 0]:
     import torch.cuda.amp as amp
     _TORCH_CUSTOM_FWD = amp.custom_fwd(cast_inputs=torch.float16)
     _TORCH_CUSTOM_BWD = amp.custom_bwd


### PR DESCRIPTION
Since PyTorch 2.4.0, torch.cuda.amp.custom_fwd(args...) is deprecated. Developers should use torch.amp.custom_fwd(args..., device_type='cuda') instead.

Document: https://pytorch.org/docs/2.4/amp.html#torch.cuda.amp.custom_fwd
